### PR TITLE
Basic認証の導入

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  before_action :basic_auth
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   private
@@ -7,5 +8,10 @@ class ApplicationController < ActionController::Base
     devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname])
   end
 
+  def basic_auth
+    authenticate_or_request_with_http_basic do |username, password|
+      username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
+    end
+  end
 
 end


### PR DESCRIPTION
## 概要
開発段階のアプリにおいて、外部からのアクセスを制限するためにBasic認証を導入しました。

## 実装内容
- ApplicationControllerに`basic_auth`メソッドを定義
- `authenticate_or_request_with_http_basic` を使用してID/パスワードによる認証を追加
- 環境変数`BASIC_AUTH_USER`, `BASIC_AUTH_PASSWORD`を使ってIDとパスワードを管理
- Renderにて環境変数を追加済み


## 関連Issue
Closes #5