### PR TITLE
一覧表示機能実装

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,7 +1,7 @@
 class PostsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
   def index
-
+    @posts = Post.all.order('created_at DESC')
   end
   def new
     @post = Post.new

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,0 +1,32 @@
+<% if user_signed_in? %>
+  <p><%= "#{current_user.nickname}さん、ようこそ！" %></p>
+  <%= link_to 'ログアウト',  destroy_user_session_path, data: {turbo_method: :delete} %>
+<% else %>
+  <%= link_to 'ログイン', new_user_session_path %> |
+  <%= link_to '新規登録', new_user_registration_path %>
+<% end %>
+
+<h1>投稿一覧</h1>
+
+<% @posts.each do |post| %>
+  <div class="post">
+    <p><strong>投稿者:</strong> <%= post.user.nickname %></p>
+    <p><strong>かかった時間:</strong> <%= post.duration %>分</p>
+    <p><strong>成果:</strong> <%= post.result %></p>
+
+    <% if post.image.attached? %>
+      <div>
+        <%= image_tag post.image, style: "max-width: 300px;" %>
+      </div>
+    <% end %>
+
+    <hr>
+  </div>
+<% end %>
+<% if @posts.any? %>
+  <% @posts.each do |post| %>
+    <!-- 上記と同じ -->
+  <% end %>
+<% else %>
+  <p>まだ投稿がありません</p>
+<% end %>


### PR DESCRIPTION
## 概要
投稿されたすべての自己投資記録を一覧表示できるようにする。

## 実施内容
- PostsController に index アクションを実装
- 投稿一覧ページ（index.html.erb）の作成
- 投稿内容（かかった時間、成果、画像、投稿者名）を一覧表示
- 投稿の並び順を created_at DESC（新しい順）に設定
- 投稿がない場合に「まだ投稿がありません」と表示
- 新規投稿ボタン・ログイン／ログアウトリンク等、ナビゲーションを仮配置

## 関連Issue
Closes #7 