### PR TITLE
投稿詳細機能の実装

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -16,6 +16,10 @@ class PostsController < ApplicationController
     end
   end
 
+  def show
+    @post = Post.find(params[:id])
+  end
+
   private
 
   def post_params

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -11,13 +11,15 @@
 <% @posts.each do |post| %>
   <div class="post">
     <p><strong>投稿者:</strong> <%= post.user.nickname %></p>
-    <p><strong>かかった時間:</strong> <%= post.duration %>分</p>
-    <p><strong>成果:</strong> <%= post.result %></p>
+    <%= link_to post_path(post.id) do %>
+      <p><strong>かかった時間:</strong> <%= post.duration %>分</p>
+      <p><strong>成果:</strong> <%= post.result %></p>
 
-    <% if post.image.attached? %>
-      <div>
-        <%= image_tag post.image, style: "max-width: 300px;" %>
-      </div>
+      <% if post.image.attached? %>
+        <div>
+          <%= image_tag post.image, style: "max-width: 300px;" %>
+        </div>
+      <% end %>
     <% end %>
 
     <hr>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,0 +1,21 @@
+
+<h1>投稿の詳細</h1>
+
+<%# 写真（画像があるときのみ表示） %>
+<% if @post.image.attached? %>
+  <div>
+    <%= image_tag @post.image, style: "max-width: 300px;" %>
+  </div>
+<% end %>
+
+<p><strong>かかった時間:</strong> <%= @post.duration %>分</p>
+<p><strong>成果:</strong> <%= @post.result %></p>
+<p><strong>投稿者:</strong> <%= @post.user.nickname %></p>
+
+<%# 編集・削除は投稿者だけに表示 %>
+<% if user_signed_in? && current_user == @post.user %>
+  <%= link_to '編集', edit_post_path(@post) %> |
+  <%= link_to '削除', post_path(@post), method: :delete, data: { confirm: '本当に削除しますか？' } %>
+<% end %>
+
+<%= link_to 'トップページに戻る', posts_path %>


### PR DESCRIPTION
## 概要
投稿の詳細を確認できる詳細ページを実装

## 実施内容
- PostsController に show アクションを追加
- 投稿詳細ページ（show.html.erb）を作成
- 投稿内容（かかった時間・成果・画像・投稿者名）を表示
- 投稿者にのみ編集・削除リンクを表示（current_user == @post.user のとき）
- 投稿画像は添付されている場合のみ表示
- 一覧ページへの戻るリンクを追加

