### PR TITLE
編集・削除機能の実装

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -20,6 +20,10 @@ class PostsController < ApplicationController
     @post = Post.find(params[:id])
   end
 
+  def edit
+    @post = Post.find(params[:id])
+  end
+
   private
 
   def post_params

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,5 +1,7 @@
 class PostsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
+  before_action :set_post, only: [:show, :edit, :update]
+  
   def index
     @posts = Post.all.order('created_at DESC')
   end
@@ -17,16 +19,28 @@ class PostsController < ApplicationController
   end
 
   def show
-    @post = Post.find(params[:id])
+
   end
 
   def edit
-    @post = Post.find(params[:id])
+
+  end
+
+  def update
+    if @post.update(post_params)
+      redirect_to post_path(@post)
+    else
+      render :edit, status: :unprocessable_entity
+    end
   end
 
   private
 
   def post_params
     params.require(:post).permit(:duration, :result, :image).merge(user_id: current_user.id)
+  end
+
+  def set_post
+    @post = Post.find(params[:id])
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,6 @@
 class PostsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
-  before_action :set_post, only: [:show, :edit, :update]
+  before_action :set_post, only: [:show, :edit, :update, :destroy]
   
   def index
     @posts = Post.all.order('created_at DESC')
@@ -32,6 +32,11 @@ class PostsController < ApplicationController
     else
       render :edit, status: :unprocessable_entity
     end
+  end
+
+  def destroy
+    @post.destroy
+    redirect_to root_path, notice: '投稿を削除しました'
   end
 
   private

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,9 @@
   </head>
 
   <body>
+    <% if notice %>
+      <p class="notice"><%= notice %></p>
+    <% end %>
     <%= yield %>
   </body>
 </html>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,0 +1,10 @@
+<h1>編集ページ</h1>
+<%= form_with(model: @post, local: true, html: { multipart: true }) do |f| %>
+  <%= render "shared/error_messages", model: f.object %>
+  <%= f.text_field :duration, placeholder: "達成にかかった時間" %><br>
+  <%= f.text_field :result, placeholder: "成し遂げたこと" %><br>
+  <%= f.file_field :image %><br>
+  <%= f.submit "編集" %>
+<% end %>
+
+<%= link_to 'トップページに戻る', root_path %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -15,7 +15,7 @@
 <%# 編集・削除は投稿者だけに表示 %>
 <% if user_signed_in? && current_user == @post.user %>
   <%= link_to '編集', edit_post_path(@post) %> |
-  <%= link_to '削除', post_path(@post), method: :delete, data: { confirm: '本当に削除しますか？' } %>
+  <%= link_to '削除', post_path(@post), data: {turbo_method: :delete, confirm: '本当に削除しますか？' } %>
 <% end %>
 
 <%= link_to 'トップページに戻る', posts_path %>


### PR DESCRIPTION
## 概要
投稿済みの記録に対して、編集・削除できる機能を実装

## 実施内容
- PostsController に edit, update, destroy アクションを追加
- 投稿編集ページ（edit.html.erb）を作成（new.html.erb を再利用）
- 投稿詳細ページに「編集」「削除」リンクを設置（ログイン中かつ投稿者のみ表示）
- 削除時にはトップページへリダイレクト＋フラッシュメッセージ表示
- 投稿画像は再選択可能（変更は任意）
- before_action で @post をセットする set_post を共通化

## 関連Issue
Closes #11 