### PR TITLE
マイページ機能の実装

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -42,7 +42,7 @@ class PostsController < ApplicationController
   def mypage
     @posts = current_user.posts.order(created_at: :desc)
   end
-  
+
   private
 
   def post_params

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,5 +1,5 @@
 class PostsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create]
+  before_action :authenticate_user!, only: [:new, :create, :mypage]
   before_action :set_post, only: [:show, :edit, :update, :destroy]
   
   def index

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -39,6 +39,10 @@ class PostsController < ApplicationController
     redirect_to root_path, notice: '投稿を削除しました'
   end
 
+  def mypage
+    @posts = current_user.posts.order(created_at: :desc)
+  end
+  
   private
 
   def post_params

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,4 +11,6 @@ class User < ApplicationRecord
                           message: 'は半角英数字混合で入力してください' 
                          }, on: :create
   end
+
+  has_many :posts
 end

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,5 +1,5 @@
 <% if user_signed_in? %>
-  <p><%= "#{current_user.nickname}さん、ようこそ！" %></p>
+  <p><%= link_to "#{current_user.nickname}さん、ようこそ！", mypage_path %></p>
   <%= link_to 'ログアウト',  destroy_user_session_path, data: {turbo_method: :delete} %>
 <% else %>
   <%= link_to 'ログイン', new_user_session_path %> |

--- a/app/views/posts/mypage.html.erb
+++ b/app/views/posts/mypage.html.erb
@@ -5,6 +5,7 @@
     <li><%= link_to 'プロフィール編集', edit_user_registration_path %></li>
     <li><%= link_to '新しい投稿を作成', new_post_path %></li>
     <li><%= link_to '一覧に戻る', posts_path %></li>
+    <li><%= link_to 'ログアウト',  destroy_user_session_path, data: {turbo_method: :delete} %></li>
   </ul>
 </nav>
 

--- a/app/views/posts/mypage.html.erb
+++ b/app/views/posts/mypage.html.erb
@@ -1,0 +1,29 @@
+<h1><%= current_user.nickname %> さんのマイページ</h1>
+
+<nav>
+  <ul>
+    <li><%= link_to 'プロフィール編集', edit_user_registration_path %></li>
+    <li><%= link_to '新しい投稿を作成', new_post_path %></li>
+    <li><%= link_to '一覧に戻る', posts_path %></li>
+  </ul>
+</nav>
+
+<hr>
+
+<h2>これまでの投稿</h2>
+
+<% if @posts.any? %>
+  <% @posts.each do |post| %>
+    <div class="post">
+      <% if post.image.attached? %>
+        <%= image_tag post.image, style: "max-width: 200px;" %><br>
+      <% end %>
+      <strong>時間:</strong> <%= post.duration %> 分<br>
+      <strong>成果:</strong> <%= post.result %><br>
+      <%= link_to '詳細を見る', post_path(post) %>
+      <hr>
+    </div>
+  <% end %>
+<% else %>
+  <p>まだ投稿がありません</p>
+<% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -10,7 +10,7 @@
 
 <p><strong>かかった時間:</strong> <%= @post.duration %>分</p>
 <p><strong>成果:</strong> <%= @post.result %></p>
-<p><strong>投稿者:</strong> <%= @post.user.nickname %></p>
+<p><strong>投稿者:</strong> <%= link_to @post.user.nickname, mypage_path %></p>
 
 <%# 編集・削除は投稿者だけに表示 %>
 <% if user_signed_in? && current_user == @post.user %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   root "posts#index"
   resources :posts
-  get 'mypage', to: 'posts#index', as: 'mypage'
+  get 'mypage', to: 'posts#mypage', as: 'mypage'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   root "posts#index"
   resources :posts
+  get 'mypage', to: 'posts#index', as: 'mypage'
 end


### PR DESCRIPTION
## 概要
ユーザーが自分の投稿だけを確認できるマイページ機能を実装しました。

## 実施内容
- posts_controller.rb に mypage アクションを追加
- ルーティングに get 'mypage', to: 'posts#mypage', as: 'mypage' を追加
- current_user.posts を使い、自分の投稿のみ取得（新しい順）
- マイページビュー（mypage.html.erb）を作成
- トップページに「〇〇さん、ようこそ！」リンクを設置し、マイページへ遷移可能に
- 投稿詳細ページ内の投稿者名にリンクを設置し、マイページへ遷移可能に
- マイページ内にメニューリンクを設置（新規投稿、プロフィール編集、一覧に戻る、ログアウト）
- 投稿がない場合の「未投稿」表示対応

## 補足
- 今回は「自分だけが見られる」仕様のため、ネストや他ユーザー表示には非対応

## 関連Issue
Closes #15 

