### PR TITLE
フォーム画面のレイアウト調整

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,5 +1,6 @@
 @import "logout_message";
 @import "posts";
+@import "devise";
 
 html {
   margin: 0;

--- a/app/assets/stylesheets/devise.scss
+++ b/app/assets/stylesheets/devise.scss
@@ -1,37 +1,38 @@
-//新規登録ページ
+// ログイン & 新規登録ページ専用：中央寄せレイアウト
+body.sessions-new,
 body.registrations-new {
-  background-color: #f5eee9 !important;
-  font-family: "Noto Sans JP", "Helvetica", sans-serif;
-  color: #333333;
-  line-height: 1.6;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  background-color: #fdf6f0 !important;
 
-  .signup-card {
-    background-color: 	#fdfaf5 !important;
-    border: 1px solid rgba(138, 182, 169, 0.15);
-    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
+  header {
+    margin-top: 2rem;
+    text-align: center;
   }
 
-  .form-label {
-    font-weight: normal;
+  main {
+    flex: 1;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 2rem 1rem;
   }
 
-  ::placeholder {
-    color: #999;
-    opacity: 0.7;
+  footer {
+    text-align: center;
+    margin-bottom: 1rem;
   }
-}
 
-//ログインページ
-body.sessions-new {
-  background-color: #f5eee9 !important;
-  font-family: "Noto Sans JP", "Helvetica", sans-serif;
-  color: #333333;
-  line-height: 1.6;
-
+  .signup-card,
   .login-card {
     background-color: #fdfaf5 !important;
     border: 1px solid rgba(138, 182, 169, 0.15);
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
+    padding: 2rem;
+    border-radius: 1rem;
+    width: 100%;
+    max-width: 600px;
   }
 
   .form-label {

--- a/app/assets/stylesheets/devise.scss
+++ b/app/assets/stylesheets/devise.scss
@@ -20,3 +20,26 @@ body.registrations-new {
     opacity: 0.7;
   }
 }
+
+//ログインページ
+body.sessions-new {
+  background-color: #f5eee9 !important;
+  font-family: "Noto Sans JP", "Helvetica", sans-serif;
+  color: #333333;
+  line-height: 1.6;
+
+  .login-card {
+    background-color: #fdfaf5 !important;
+    border: 1px solid rgba(138, 182, 169, 0.15);
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
+  }
+
+  .form-label {
+    font-weight: normal;
+  }
+
+  ::placeholder {
+    color: #999;
+    opacity: 0.7;
+  }
+}

--- a/app/assets/stylesheets/devise.scss
+++ b/app/assets/stylesheets/devise.scss
@@ -1,0 +1,22 @@
+//新規登録ページ
+body.registrations-new {
+  background-color: #f5eee9 !important;
+  font-family: "Noto Sans JP", "Helvetica", sans-serif;
+  color: #333333;
+  line-height: 1.6;
+
+  .signup-card {
+    background-color: 	#fdfaf5 !important;
+    border: 1px solid rgba(138, 182, 169, 0.15);
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
+  }
+
+  .form-label {
+    font-weight: normal;
+  }
+
+  ::placeholder {
+    color: #999;
+    opacity: 0.7;
+  }
+}

--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -113,3 +113,53 @@ body.posts-new {
   }
 }
 
+//編集ページ
+body.posts-edit {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  background-color: #f5eee9;
+  font-family: "Noto Sans JP", sans-serif;
+
+  main {
+    flex: 1;
+    display: flex;
+    justify-content: center;
+    padding: 3rem 1rem 2rem;
+  }
+
+  footer {
+    text-align: center;
+    margin-top: auto;
+    padding: 1rem 0;
+    background-color: #f4e3d7;
+    color: #6e5a47;
+    font-size: 0.9rem;
+  }
+
+  .post-form-card {
+    background-color: #fdfaf5;
+    border: 1px solid rgba(138, 182, 169, 0.15);
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
+    border-radius: 1rem;
+    padding: 2.5rem 3rem;
+    width: 100%;
+    max-width: 960px;
+  }
+
+  .form-label {
+    font-weight: normal;
+    color: #4e3c2f;
+  }
+
+  .form-control {
+    font-size: 1rem;
+  }
+
+  ::placeholder {
+    color: #999;
+    opacity: 0.7;
+  }
+}
+
+

--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -1,3 +1,4 @@
+//一覧ページ
 body.posts-index {
   background-color: #f5eee9; // ← 落ち着いたベージュなど
 }
@@ -61,3 +62,54 @@ body.posts-index {
   object-fit: cover;
   border-radius: 0.5rem;
 }
+
+//新規投稿ページ
+body.posts-new {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  background-color: #f5eee9;
+  font-family: "Noto Sans JP", sans-serif;
+
+  main {
+    flex: 1; // ← これでmainが余ったスペースを埋める
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 2rem 1rem;
+  }
+
+  footer {
+    text-align: center;
+    margin-top: auto; // ← これで最下部に寄せる
+    padding: 1rem 0;
+    background-color: #f4e3d7;
+    color: #6e5a47;
+    font-size: 0.9rem;
+  }
+
+  .post-form-card {
+    background-color: #fdfaf5;
+    border: 1px solid rgba(138, 182, 169, 0.15);
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
+    border-radius: 1rem;
+    padding: 2rem;
+    width: 100%;
+    max-width: 600px;
+  }
+
+  .form-label {
+    font-weight: normal;
+    color: #4e3c2f;
+  }
+
+  .form-control {
+    font-size: 1rem;
+  }
+
+  ::placeholder {
+    color: #999;
+    opacity: 0.7;
+  }
+}
+

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,34 +1,36 @@
-<h2>Sign up</h2>
+<div class="container my-5">
+  <div class="signup-card p-4 rounded-3 shadow-sm bg-white mx-auto" style="max-width: 600px;">
+    <h2 class="text-center mb-4 text-muted">新しく利用をはじめる</h2>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+    <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+      <%= render "devise/shared/error_messages", resource: resource %>
 
-   <div class="field">
-    <%= f.label :nickname %><br />
-    <%= f.text_field :nickname, autofocus: true, autocomplete: "nickname" %>
+      <div class="mb-3">
+        <%= f.label :nickname, "ニックネーム", class: "form-label text-dark" %>
+        <%= f.text_field :nickname, class: "form-control rounded-3", placeholder: "ニックネーム" %>
+      </div>
+
+      <div class="mb-3">
+        <%= f.label :email, "メールアドレス", class: "form-label text-dark" %>
+        <%= f.email_field :email, class: "form-control rounded-3", placeholder: "example@tokino.com" %>
+      </div>
+
+      <div class="mb-3">
+        <%= f.label :password, "パスワード", class: "form-label text-dark" %>
+        <% if @minimum_password_length %>
+          <small class="form-text text-muted">（<%= @minimum_password_length %>文字以上）</small>
+        <% end %>
+        <%= f.password_field :password, class: "form-control rounded-3", placeholder: "6文字以上で入力してください" %>
+      </div>
+
+      <div class="mb-4">
+        <%= f.label :password_confirmation, "パスワード（確認）", class: "form-label text-dark" %>
+        <%= f.password_field :password_confirmation, class: "form-control rounded-3", placeholder: "もう一度入力してください" %>
+      </div>
+
+      <div class="d-grid">
+        <%= f.submit "じかんの記録をはじめる", class: "btn btn-outline-success rounded-3" %>
+      </div>
+    <% end %>
   </div>
-
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password %>
-    <% if @minimum_password_length %>
-    <em>(<%= @minimum_password_length %> characters minimum)</em>
-    <% end %><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Sign up" %>
-  </div>
-
-  <%= link_to 'トップページに戻る', '#' %> <%# リンク先指定 %>
-<% end %>
+</div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,30 +1,29 @@
-<h2>Log in</h2>
+<div class="container my-5">
+  <div class="login-card p-4 rounded-3 shadow-sm bg-white mx-auto" style="max-width: 600px;">
+    <h2 class="text-center mb-4 text-muted">ログインする</h2>
 
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+      <%= render "devise/shared/error_messages", resource: resource %>
+
+      <div class="mb-3">
+        <%= f.label :email, "メールアドレス", class: "form-label text-dark" %>
+        <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control rounded-3", placeholder: "example@tokino.com" %>
+      </div>
+
+      <div class="mb-4">
+        <%= f.label :password, "パスワード", class: "form-label text-dark" %>
+        <%= f.password_field :password, autocomplete: "current-password", class: "form-control rounded-3", placeholder: "パスワードを入力してください" %>
+      </div>
+
+      <div class="d-grid mb-3">
+        <%= f.submit "ログイン", class: "btn btn-outline-success rounded-3" %>
+      </div>
+
+      <div class="text-center">
+        <%= link_to "パスワードを忘れた方はこちら", new_password_path(resource_name), class: "text-muted small" %>
+      </div>
+    <% end %>
   </div>
-
-  <div class="field">
-    <%= f.label :password %><br />
-    <%= f.password_field :password, autocomplete: "current-password" %>
-  </div>
-
-  <% if devise_mapping.rememberable? %>
-    <div class="field">
-      <%= f.check_box :remember_me %>
-      <%= f.label :remember_me %>
-    </div>
-  <% end %>
-
-  <div class="actions">
-    <%= f.submit "Log in" %>
-  </div>
-
-  <%= link_to 'トップページに戻る', '#' %>  <%# リンク先指定 %>
-  <%= link_to '新規登録', '#' %>           <%# リンク先指定 %>
-<% end %>
+</div>
 
 

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,10 +1,35 @@
-<h1>編集ページ</h1>
-<%= form_with(model: @post, local: true, html: { multipart: true }) do |f| %>
-  <%= render "shared/error_messages", model: f.object %>
-  <%= f.text_field :duration, placeholder: "達成にかかった時間" %><br>
-  <%= f.text_field :result, placeholder: "成し遂げたこと" %><br>
-  <%= f.file_field :image %><br>
-  <%= f.submit "編集" %>
-<% end %>
+<main>
+  <div class="container">
+    <div class="post-form-card p-4 rounded-3 shadow-sm mx-auto" style="max-width: 960px;">
+      <h2 class="text-center mb-4 text-muted">記録を編集する</h2>
 
-<%= link_to 'トップページに戻る', root_path %>
+      <%= form_with(model: @post, local: true, html: { multipart: true }) do |f| %>
+        <%= render "shared/error_messages", model: f.object %>
+
+        <!-- duration 入力 -->
+        <div class="mb-3">
+          <%= f.label :duration, "かけた時間（分）", class: "form-label text-dark" %>
+          <%= f.number_field :duration, class: "form-control rounded-3", min: 0, placeholder: "例: 45" %>
+        </div>
+
+        <!-- result 入力 -->
+        <div class="mb-3">
+          <%= f.label :result, "やってみたこと", class: "form-label text-dark" %>
+          <%= f.text_area :result, class: "form-control rounded-3", rows: 4, placeholder: "どんな時間を過ごしましたか？" %>
+        </div>
+
+        <!-- 画像添付 -->
+        <div class="mb-3">
+          <%= f.label :image, "記録写真（任意）", class: "form-label text-dark" %>
+          <%= f.file_field :image, class: "form-control" %>
+        </div>
+
+        <!-- 送信ボタン -->
+        <div class="d-grid">
+          <%= f.submit "記録を更新する", class: "btn btn-outline-success rounded-3" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</main>
+

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,10 +1,35 @@
-<h1>新規投稿ページ</h1>
-<%= form_with(model: @post, local: true, html: { multipart: true }) do |f| %>
-  <%= render "shared/error_messages", model: f.object %>
-  <%= f.text_field :duration, placeholder: "達成にかかった時間" %><br>
-  <%= f.text_field :result, placeholder: "成し遂げたこと" %><br>
-  <%= f.file_field :image %><br>
-  <%= f.submit "投稿" %>
-<% end %>
+<main>
+  <div class="container">
+    <div class="post-form-card p-4 rounded-3 shadow-sm mx-auto" style="max-width: 600px;">
+      <h2 class="text-center mb-4 text-muted">じかんのあと を記録する</h2>
 
-<%= link_to 'トップページに戻る', root_path %>
+      <%= form_with(model: @post, local: true, html: { multipart: true }) do |f| %>
+        <%= render "shared/error_messages", model: f.object %>
+
+        <!-- duration 入力（分のみ） -->
+        <div class="mb-3">
+          <%= f.label :duration, "かけた時間（分）", class: "form-label text-dark" %>
+          <%= f.number_field :duration, class: "form-control rounded-3", min: 0, placeholder: "例: 45" %>
+        </div>
+
+        <!-- result 入力 -->
+        <div class="mb-3">
+          <%= f.label :result, "やってみたこと", class: "form-label text-dark" %>
+          <%= f.text_area :result, class: "form-control rounded-3", rows: 4, placeholder: "どんな時間を過ごしましたか？" %>
+        </div>
+
+        <!-- 画像添付 -->
+        <div class="mb-3">
+          <%= f.label :image, "記録写真（任意）", class: "form-label text-dark" %>
+          <%= f.file_field :image, class: "form-control" %>
+        </div>
+
+        <!-- 送信ボタン -->
+        <div class="d-grid">
+          <%= f.submit "記録する", class: "btn btn-outline-success rounded-3" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</main>
+


### PR DESCRIPTION
## 概要
Devise関連（ログイン・新規登録）および投稿関連（新規投稿・編集）のフォーム画面のレイアウトを調整しました。
ユーザーが迷わず入力できるよう、共通のデザインパターンで統一しています。

## 主な変更点
- 各フォーム画面にカード型のレイアウトを適用（最大幅・余白・影など）
- 背景色やフォントを含む画面全体の雰囲気を統一
- Bootstrapのクラス（`form-control`, `btn`, `rounded-3` など）を用いて、入力欄やボタンを調整
- フッターが画面下部に固定されるよう、`flex`レイアウトを導入（ページごとに限定）
- `application.html.erb` の `<body class="controller-action">` 構造に合わせたセレクタ設計で、他ページへの影響を最小化

## 対象画面
- ユーザー新規登録（`registrations#new`）
- ログイン（`sessions#new`）
- 投稿作成（`posts#new`）
- 投稿編集（`posts#edit`）

## 動作確認
- 各画面が中央寄せのカード形式で表示されること
- フォームの項目・プレースホルダー・ボタンが適切に整っていること
- 画面下部にフッターが自然に表示されること
- 他の画面（投稿一覧やトップページなど）のレイアウトに影響が出ていないこと

## 関連Issue
Closes #28 