### PR TITLE
詳細ページレイアウト

### DIFF
--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -162,4 +162,56 @@ body.posts-edit {
   }
 }
 
+//詳細ページ
+body.posts-show {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  background-color: #f5eee9;
+  font-family: "Noto Sans JP", sans-serif;
+
+  main {
+    flex: 1;
+    display: flex;
+    justify-content: center;
+    padding: 3rem 1rem 2rem;
+  }
+
+  footer {
+    margin-top: auto;
+    text-align: center;
+    padding: 1rem 0;
+    background-color: #f4e3d7;
+    color: #6e5a47;
+    font-size: 0.9rem;
+  }
+
+  .post-detail-card {
+    background-color: #fdfaf5;
+    border: 1px solid rgba(138, 182, 169, 0.15);
+    border-radius: 1rem;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
+    padding: 2.5rem 3rem;
+    width: 100%;
+    max-width: 720px;
+  }
+
+  .post-detail-card p {
+    font-size: 1.05rem;
+    color: #4e3c2f;
+    line-height: 1.6;
+  }
+
+  .btn {
+    font-weight: 500;
+  }
+
+  .img-fluid {
+    max-width: 100%;
+    height: auto;
+    object-fit: cover;
+    border-radius: 0.5rem;
+  }
+}
+
 

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,21 +1,33 @@
+<main>
+  <div class="container my-5">
+    <div class="post-detail-card p-4 rounded-3 shadow-sm mx-auto" style="max-width: 720px;">
+      <%# タイトル %>
+      <h2 class="text-center mb-4 text-muted">じかんのあと の記録</h2>
 
-<h1>投稿の詳細</h1>
+      <%# 画像表示 %>
+      <% if @post.image.attached? %>
+        <div class="mb-3 text-center">
+          <%= image_tag @post.image, class: "img-fluid rounded", style: "max-height: 300px;" %>
+        </div>
+      <% else %>
+        <div class="mb-3 text-center">
+          <%= image_tag "sprout.png", alt: "記録写真は登録されていません", class: "img-fluid rounded", style: "max-height: 300px;" %>
+        </div>
+      <% end %>
 
-<%# 写真（画像があるときのみ表示） %>
-<% if @post.image.attached? %>
-  <div>
-    <%= image_tag @post.image, style: "max-width: 300px;" %>
+      <%# 投稿データ %>
+      <p><strong>かかった時間:</strong> <%= @post.duration %>分</p>
+      <p><strong>やってみたこと:</strong> <%= @post.result %></p>
+      <p><strong>投稿者:</strong> <%= link_to @post.user.nickname, mypage_path %></p>
+
+      <%# 編集・削除ボタン（本人のみ） %>
+      <% if user_signed_in? && current_user == @post.user %>
+        <div class="mt-4 d-flex gap-3 justify-content-center">
+          <%= link_to '編集', edit_post_path(@post), class: "btn btn-outline-primary rounded-3" %>
+          <%= link_to '削除', post_path(@post), data: { turbo_method: :delete, confirm: '本当に削除しますか？' }, class: "btn btn-outline-danger rounded-3" %>
+        </div>
+      <% end %>
+    </div>
   </div>
-<% end %>
+</main>
 
-<p><strong>かかった時間:</strong> <%= @post.duration %>分</p>
-<p><strong>成果:</strong> <%= @post.result %></p>
-<p><strong>投稿者:</strong> <%= link_to @post.user.nickname, mypage_path %></p>
-
-<%# 編集・削除は投稿者だけに表示 %>
-<% if user_signed_in? && current_user == @post.user %>
-  <%= link_to '編集', edit_post_path(@post) %> |
-  <%= link_to '削除', post_path(@post), data: {turbo_method: :delete, confirm: '本当に削除しますか？' } %>
-<% end %>
-
-<%= link_to 'トップページに戻る', posts_path %>


### PR DESCRIPTION
## 概要

投稿詳細ページ（`posts#show`）のレイアウトを調整し、他のフォーム画面・投稿一覧ページと統一された、やさしいデザインに整えました。

## 主な変更点
- 投稿詳細画面をカード風デザインに調整（`.post-detail-card`）
- 画像がある場合は投稿写真を中央表示、ない場合は代替画像 `sprout.png` を表示
- 投稿内容（時間・やってみたこと・投稿者）を読みやすく表示
- 編集・削除ボタンは投稿者本人にのみ表示、デザインをボタン化
- レイアウト崩れ防止のため、背景色やフッター固定などを `body.posts-show` スコープで制御
- 他ページに影響が出ないようにスタイルを限定

## 対象画面
- 投稿詳細ページ（`posts#show`）

## 動作確認
- 投稿に画像がある場合 → 正しく表示されること
- 投稿に画像がない場合 → `sprout.png` が表示されること
- 投稿者本人のみ「編集」「削除」ボタンが表示されること
- デザインが他のページと調和していること
- 他のページのレイアウトに影響が出ていないこと

## 補足
- 代替画像 `sprout.png` は `app/assets/images` に配置
- 最大幅は `720px` に統一し、余白や丸み・影などで柔らかい印象を演出

## 関連Issue
Closes #35 
