### PR TITLE
パスワード再設定メール送信ページレイアウト

### DIFF
--- a/app/assets/stylesheets/devise.scss
+++ b/app/assets/stylesheets/devise.scss
@@ -44,3 +44,64 @@ body.registrations-new {
     opacity: 0.7;
   }
 }
+
+//パスワード再設定メール送信ページ
+body.passwords-new {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  background-color: #fdf6f0 !important;
+
+  header {
+    margin-top: 2rem;
+    text-align: center;
+  }
+
+  main {
+    flex: 1;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 2rem 1rem;
+  }
+
+  footer {
+    text-align: center;
+    margin-bottom: 1rem;
+  }
+
+  .reset-password-card {
+    background-color: #fdfaf5 !important;
+    border: 1px solid rgba(138, 182, 169, 0.15);
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
+    padding: 2rem;
+    border-radius: 1rem;
+    width: 100%;
+    max-width: 600px;
+  }
+
+  .form-label {
+    font-weight: normal;
+  }
+
+  ::placeholder {
+    color: #999;
+    opacity: 0.7;
+  }
+}
+
+.devise-links-muted {
+  display: flex;
+  justify-content: center;
+  gap: 2rem;
+
+  a.link-muted {
+    color: #6c757d; // text-muted 相当
+    font-size: 0.95rem;
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,16 +1,24 @@
-<h2>Forgot your password?</h2>
+<div class="container my-5">
+  <div class="reset-password-card p-4 rounded-3 shadow-sm bg-white mx-auto" style="max-width: 600px;">
+    <h2 class="text-center mb-4 text-muted">パスワードを再設定する</h2>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+      <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+      <div class="mb-3">
+        <%= f.label :email, "登録済みメールアドレス", class: "form-label text-dark" %>
+        <%= f.email_field :email, class: "form-control rounded-3", autofocus: true, autocomplete: "email", placeholder: "example@tokino.com" %>
+      </div>
+
+      <div class="d-grid">
+        <%= f.submit "再設定メールを送信する", class: "btn btn-outline-success rounded-3" %>
+      </div>
+    <% end %>
+
+    <div class="devise-links-muted text-center mt-4">
+      <%= link_to "ログイン", new_session_path(resource_name), class: "link-muted" %>
+      <%= link_to "新規登録", new_registration_path(resource_name), class: "link-muted" %>
+    </div>
   </div>
+</div>
 
-  <div class="actions">
-    <%= f.submit "Send me reset password instructions" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -2,7 +2,7 @@ require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
-
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
   # In the development environment your application's code is reloaded any time
   # it changes. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -5,6 +5,7 @@ Rails.application.configure do
 
   # Code is not reloaded between requests.
   config.enable_reloading = false
+  config.action_mailer.default_url_options = { host: 'original_app-42267.onrender.com' }
 
   # Eager load code on boot. This eager loads most of Rails and
   # your application in memory, allowing both threaded web servers


### PR DESCRIPTION
## 概要
パスワード再設定メール送信画面（`devise/passwords#new`）のレイアウトを整え、  
他の認証系画面と世界観を統一しました。

## 主な変更点
- `.reset-password-card` を使ってカード風デザインを実装
- `body.passwords-new` スコープにより他ページへの影響を排除
- フォームの文言を日本語化
  - `メールアドレス` → `登録済みメールアドレス`
  - 送信ボタン → `再設定メールを送信する`
- 下部リンク（ログイン・新規登録）を `_links.html.erb` を使わず、個別に日本語で横並び配置
- デザインは `text-muted` 系の落ち着いた配色で調整

## 対象画面
- `/users/password/new`

## 備考
- メールリンク生成のための `config.action_mailer.default_url_options[:host]` 設定は完了済み（`development.rb` に記載）
- ただし、**実際のメール送信機能（SMTPなど）の設定は未導入**
  - 今のところは見た目・レイアウトの調整のみ行っており、送信確認はしていません
- 再設定ページ（`passwords#edit`）はトークン付きリンクからのみアクセスされるため、今回の調整には含まれていません

## 関連Issue
Closes #39 
