### PR TITLE
ヘッダー内容修正

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,10 +20,12 @@
     <!-- ヘッダー -->
     <header>
       <div class="container d-flex justify-content-between align-items-center">
-        <strong class="fs-4">ときの図書室</strong>
+        <%= link_to root_path, class: "fs-4 text-decoration-none fw-bold", style: "color: #6e5a47;" do %>
+          ときの図書室
+        <% end %>
         <nav>
           <% if user_signed_in? %>
-            <%= link_to "ホーム", root_path, class: "btn-library" %>
+            <%= link_to "マイページ", mypage_path, class: "btn-library" %>
             <%= link_to "記録する", new_post_path, class: "btn-library" %>
             <%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: :delete }, class: "btn-library" %>
           <% else %>


### PR DESCRIPTION
## 概要
ヘッダーの視認性と導線改善のため、以下の調整を行いました。

## 主な変更点

- 「ときの図書室」ロゴを `root_path` にリンク化
  - 見た目（フォントサイズ・色・装飾）は既存と同様に維持
- トップページへのアクセスをロゴで担保できるようになったため、「ホーム」ボタンは削除
- ログイン時に「マイページ」ボタンをナビゲーションに追加し、ユーザー自身の記録画面へすぐ遷移できるよう改善

## 対象画面
- 全ページ共通ヘッダー（`application.html.erb`）

## 備考
- 見た目に大きな変化はなく、導線の整理を目的とした最小限の改善です
- 今後、ヘッダーが複雑化した場合はドロップダウンメニュー導入も検討余地あり
