### PR TITLE
トップページ未ログイン時のボタン文言を調整

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -12,8 +12,8 @@
         <%= link_to "みんなの記録を見る", posts_path, class: "btn btn-outline-light btn-lg" %>
 
         <% unless user_signed_in? %>
-          <%= link_to "ログイン", new_user_session_path, class: "btn btn-outline-light btn-lg" %>
-          <%= link_to "新規登録", new_user_registration_path, class: "btn btn-outline-light btn-lg" %>
+          <%= link_to "ログインする", new_user_session_path, class: "btn btn-outline-light btn-lg" %>
+          <%= link_to "はじめての方はこちら", new_user_registration_path, class: "btn btn-outline-light btn-lg" %>
         <% end %>
       </div>
     </main>


### PR DESCRIPTION
## 概要
トップページ中央に表示される未ログイン時のメニューボタンのうち、  
ログイン・新規登録の文言を以下のように変更しました。

## 変更前 → 変更後

| 変更対象 | 変更内容 |
|----------|----------|
| ログイン | 「ログイン」 → 「ログインする」 |
| 新規登録 | 「新規登録」 → 「はじめての方はこちら」 |

## 目的
- ヘッダーとの役割の違いを明確化（トップページは“選択画面”としての役割を重視）
- 結果的にボタンのバランスも改善されたため、見た目の整合性も向上

## 対象画面
- トップページ（未ログイン時）

## 備考
- `application.html.erb` にあるヘッダーボタンはそのままの文言（機能的導線として明確に）
- 今後もトップページは“メニュー的な特別な画面”として扱う方針で進行中
