### PR TITLE
投稿詳細ページの投稿者名リンクを自分の投稿時のみ表示に限定

### DIFF
--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -18,7 +18,14 @@
       <%# 投稿データ %>
       <p><strong>かかった時間:</strong> <%= @post.duration %>分</p>
       <p><strong>やってみたこと:</strong> <%= @post.result %></p>
-      <p><strong>投稿者:</strong> <%= link_to @post.user.nickname, mypage_path %></p>
+      <p><strong>投稿者:</strong>
+        <% if user_signed_in? && current_user == @post.user %>
+          <%= link_to @post.user.nickname, mypage_path, class: "text-decoration-none" %>
+        <% else %>
+          <%= @post.user.nickname %>
+        <% end %>
+      </p>
+
 
       <%# 編集・削除ボタン（本人のみ） %>
       <% if user_signed_in? && current_user == @post.user %>


### PR DESCRIPTION
## 概要
投稿詳細ページにて、投稿者名をマイページリンクにする条件を制限しました。

## 変更内容
- ログイン中のユーザーが、その投稿の投稿者である場合のみ `@post.user.nickname` にリンクを付与
- 他人の投稿ではリンクを除去し、名前のみプレーンテキストで表示

## 目的
- 他人の投稿でもリンクが表示されていると、誤って「自分のマイページに遷移」してしまう挙動が混乱を招くため
- 現状ではマイページが自分専用の機能に限定されているため、他人の名前リンクは意味を持たない
- UIの整合性と意図の明確化を図る

## 対象画面
- 投稿詳細ページ（`posts/show.html.erb`）

## 補足
- 将来的に他ユーザーのプロフィールページが実装された際には再調整を検討。

## 関連Issue
Closes #45 
