### PR TITLE
フラッシュメッセージ・アラート表示、レイアウト調整

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,12 +15,12 @@ body {
   color: #333;
   margin: 0;
   padding: 0;
-  overflow-x: hidden; // ← ここに移してOK
+  overflow-x: hidden;
 }
 
 header {
-  background-color: #f4e3d7;  // フッターと統一
-  color: #6e5a47;             // フッターと統一
+  background-color: #f4e3d7;
+  color: #6e5a47;
   padding: 1rem 0;
   border-bottom: 1px solid #d6c1af;
 }
@@ -58,6 +58,7 @@ header a:hover {
   }
 }
 
+//オーバーレイ
 .library-background {
   background-image: image-url('library_big.png');
   background-size: cover;
@@ -89,7 +90,7 @@ header a:hover {
 
 .library-background .container {
   position: relative;
-  z-index: 2; // ← オーバーレイより上に文字を表示
+  z-index: 2;
 }
 
 main {
@@ -108,4 +109,28 @@ footer {
 
 body {
   font-family: 'Noto Sans JP', sans-serif !important;
+}
+
+//フラッシュメッセージ・アラート
+.flash {
+  margin: 1rem auto;
+  padding: 1rem 1.25rem;
+  max-width: 600px;
+  border-radius: 0.75rem;
+  font-size: 1rem;
+  text-align: center;
+  font-weight: 500;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+.flash-notice {
+  background-color: #f1ede7;
+  color: #5e4a3d;
+  border: 1px solid #d8cfc7;
+}
+
+.flash-alert {
+  background-color: #f8d7da;
+  color: #842029;
+  border: 1px solid #f5c2c7;
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,9 +35,13 @@
         </nav>
       </div>
     </header>
-    <% if notice %>
-      <p class="notice"><%= notice %></p>
+    <!-- フラッシュメッセージ・アラート -->
+    <% flash.each do |type, message| %>
+      <% if message.present? %>
+        <div class="flash flash-<%= type %>"><%= message %></div>
+      <% end %>
     <% end %>
+
     <!-- オーバーレイ用のHTML（常に含める） -->
     <div id="force-exit-overlay">
       <div class="message">
@@ -45,6 +49,7 @@
         また明日、集中した時間を一緒に作ろう☕️
       </div>
     </div>
+    
     <!-- メイン -->
     <main>
       <%= yield %>


### PR DESCRIPTION
## 概要
`flash[:alert]` が表示されない状態だったため、メッセージの見逃しが起きていた問題を修正しました。  
同時に `flash[:notice]` 含め、メッセージ表示スタイルをアプリ全体で統一しました。

## 主な変更点
- `application.html.erb` のヘッダー下に `flash.each` を追加し、`notice` / `alert` など任意のキーに対応
- `application.scss` に `flash`, `flash-notice`, `flash-alert` を追加
  - ベージュ・赤系カラーでやさしい世界観に調和
  - 中央寄せ・角丸・影付きで柔らかい印象に

## 対象画面
- 全ページ共通ヘッダー配下のフラッシュメッセージ領域
- Deviseログイン／登録／再設定フォームなどのエラー表示

## 関連Issue
Closes #49 