### PR TITLE
投稿に日付表記追加

### DIFF
--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -10,7 +10,7 @@
           <%= link_to post_path(post.id), class: "post-link" do %>
             <p><strong>かかった時間:</strong> <%= post.duration %>分</p>
             <p><strong>成果:</strong> <%= truncate(post.result, length: 80) %></p>
-
+      
             <div class="post-image">
               <% if post.image.attached? %>
                 <%= image_tag post.image, class: "img-fluid rounded" %>
@@ -18,6 +18,7 @@
                 <%= image_tag "notebook3.png", class: "img-fluid rounded" %>
               <% end %>
             </div>
+            <p><strong>投稿日:</strong> <%= post.created_at.strftime('%Y年%m月%d日') %></p>
           <% end %>
         </div>
       <% end %>

--- a/app/views/posts/mypage.html.erb
+++ b/app/views/posts/mypage.html.erb
@@ -21,6 +21,7 @@
                   <%= image_tag "sprout.png", class: "img-fluid rounded" %>
                 <% end %>
               </div>
+              <p><strong>投稿日:</strong> <%= post.created_at.strftime('%Y年%m月%d日') %></p>
             <% end %>
           </div>
         <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -25,7 +25,7 @@
           <%= @post.user.nickname %>
         <% end %>
       </p>
-
+      <p><strong>投稿日:</strong> <%= @post.created_at.strftime('%Y年%m月%d日') %></p>
 
       <%# 編集・削除ボタン（本人のみ） %>
       <% if user_signed_in? && current_user == @post.user %>


### PR DESCRIPTION
## 概要
投稿の内容に加えて、投稿された日付（`created_at`）を表示するようにしました。

## 変更点
- `created_at` を `strftime('%Y年%m月%d日')` 形式で表示

## 表示形式
- `2025年05月07日` のような和風スタイル（世界観に合わせた表記）

## 目的
- 投稿の時間軸をユーザーが視覚的に把握できるようにするため
- 積み重ねの感覚や達成感が得られやすくなる
- アプリの世界観「ときの記録」によりマッチする表現を取り入れるため

## 対象画面
- 投稿詳細ページ
- 投稿一覧ページ
- マイページ

## 関連Issue
Closes #51 