### PR TITLE
削除実行後のリダイレクト先修正

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -36,7 +36,13 @@ class PostsController < ApplicationController
 
   def destroy
     @post.destroy
-    redirect_to root_path, notice: '投稿を削除しました'
+    
+    case params[:from]
+    when 'mypage'
+      redirect_to mypage_path, notice: '投稿を削除しました'
+    else
+      redirect_to posts_path, notice: '投稿を削除しました'
+    end
   end
 
   def mypage

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -7,7 +7,7 @@
         <div class="post-card">
           <p class="post-author"><strong><%= post.user.nickname %></strong> さんの記録</p>
 
-          <%= link_to post_path(post.id), class: "post-link" do %>
+          <%= link_to post_path(post, from: 'index'), class: "post-link" do %>
             <p><strong>かかった時間:</strong> <%= post.duration %>分</p>
             <p><strong>成果:</strong> <%= truncate(post.result, length: 80) %></p>
       

--- a/app/views/posts/mypage.html.erb
+++ b/app/views/posts/mypage.html.erb
@@ -10,7 +10,7 @@
           <div class="post-card">
             <p class="post-author">あなたの記録</p>
 
-            <%= link_to post_path(post), class: "post-link" do %>
+            <%= link_to post_path(post, from: 'mypage'), class: "post-link" do %>
               <p><strong>かかった時間:</strong> <%= post.duration %>分</p>
               <p><strong>成果:</strong> <%= truncate(post.result, length: 80) %></p>
 

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -31,7 +31,7 @@
       <% if user_signed_in? && current_user == @post.user %>
         <div class="mt-4 d-flex gap-3 justify-content-center">
           <%= link_to '編集', edit_post_path(@post), class: "btn btn-outline-primary rounded-3" %>
-          <%= link_to '削除', post_path(@post), data: { turbo_method: :delete, confirm: '本当に削除しますか？' }, class: "btn btn-outline-danger rounded-3" %>
+          <%= link_to '削除', post_path(@post, from: params[:from]), data: { turbo_method: :delete, confirm: '本当に削除しますか？' }, class: "btn btn-outline-danger rounded-3" %>
         </div>
       <% end %>
     </div>


### PR DESCRIPTION
## 概要
これまで投稿詳細ページから削除を実行すると常にトップページにリダイレクトされていた。
しかし詳細ページへのアクセス方法が「投稿一覧ページから」と「マイページから」の2通りあるため、削除後は元のページに戻る方が自然な操作導線となる。
そのためアクセス元に応じてリダイレクト先を切り替えるよう実装を修正した。

## 実施内容
- 投稿一覧ページ及びマイページからの詳細ページへのリンクにfromパラメータを追加
- 投稿詳細ページの削除ボタンにparams[:from]を引き継ぐようにコードを修正
- コントローラーのdestroyアクションにて、params[:from]の値に応じたリダイレクト先を条件分岐