### PR TITLE
投稿後のリダイレクト先をトップページからマイページに変更

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -12,7 +12,7 @@ class PostsController < ApplicationController
   def create
     @post = Post.new(post_params)
     if @post.save
-      redirect_to root_path
+      redirect_to mypage_path
     else
       render :new, status: :unprocessable_entity
     end


### PR DESCRIPTION
## 概要
これまで新規投稿後のリダイレクト先がトップページ（`/`）になっていたが、投稿完了後にトップページへ戻る導線は「記録の流れが断ち切られる」印象を与えてしまう。  
より自然で直感的な導線にするため、投稿後の遷移先をマイページに統一した。

## 実施内容
- `PostsController#create` の `redirect_to` を `root_path` から `mypage_path` に変更
- 投稿完了後に自分の記録が一覧表示されるマイページへ遷移するように修正

## 関連Issue
Closes #56 