### PR TITLE
投稿に「いいね」機能を追加する

### DIFF
--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,0 +1,2 @@
+class LikesController < ApplicationController
+end

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,2 +1,24 @@
 class LikesController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_post
+
+  def create
+    post = Post.find(params[:post_id])
+    post.likes.create(user: current_user)
+    redirect_back fallback_location: post_path
+  end
+
+  def destroy
+    post = Post.find(params[:post_id])
+    like = post.likes.find_by(user: current_user)
+    like.destroy if like
+    redirect_back fallback_location: posts_path
+  end
+
+
+  private
+
+  def set_post
+    @post = Post.find(params[:post_id])
+  end
 end

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -5,14 +5,14 @@ class LikesController < ApplicationController
   def create
     post = Post.find(params[:post_id])
     post.likes.create(user: current_user)
-    redirect_back fallback_location: post_path
+    redirect_back fallback_location: post_path(post)
   end
 
   def destroy
     post = Post.find(params[:post_id])
     like = post.likes.find_by(user: current_user)
     like.destroy if like
-    redirect_back fallback_location: posts_path
+    redirect_back fallback_location: posts_path(post)
   end
 
 

--- a/app/helpers/likes_helper.rb
+++ b/app/helpers/likes_helper.rb
@@ -1,0 +1,2 @@
+module LikesHelper
+end

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -1,0 +1,2 @@
+class Like < ApplicationRecord
+end

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -1,2 +1,6 @@
 class Like < ApplicationRecord
+  belongs_to :user
+  belongs_to :post
+
+  validates :user_id, uniqueness: { scope: :post_id }
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -2,6 +2,8 @@ class Post < ApplicationRecord
 
   belongs_to :user
   has_one_attached :image
+  has_many :likes, dependent: :destroy
+  has_many :liking_users, through: :likes, source: :user
   
   with_options presence: true do
     validates :duration, :result, :user_id

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,4 +13,6 @@ class User < ApplicationRecord
   end
 
   has_many :posts
+  has_many :likes, dependent: :destroy
+  has_many :liked_posts, through: :likes, source: :post
 end

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -43,6 +43,7 @@
       <% else %>
         <p>ログインするといいねできます</p>
       <% end %>
+      <p>いいね数：<%= @post.likes.count %></p>
     </div>
   </div>
 </main>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -34,6 +34,15 @@
           <%= link_to '削除', post_path(@post, from: params[:from]), data: { turbo_method: :delete, confirm: '本当に削除しますか？' }, class: "btn btn-outline-danger rounded-3" %>
         </div>
       <% end %>
+
+      <%# いいねボタン %>
+      <% if current_user && current_user.liked_posts.include?(@post) %>
+        <%= button_to '♥ いいね済み', post_like_path(@post), method: :delete, class: 'liked-button' %>
+      <% elsif current_user %>
+        <%= button_to '♡ いいね', post_like_path(@post), method: :post, class: 'like-button' %>
+      <% else %>
+        <p>ログインするといいねできます</p>
+      <% end %>
     </div>
   </div>
 </main>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   devise_for :users
   root "home#index"
-  resources :posts
+  resources :posts do
+    resource :like, only: [:create, :destroy]
+  end
   get 'mypage', to: 'posts#mypage', as: 'mypage'
 end

--- a/db/migrate/20250517122131_create_likes.rb
+++ b/db/migrate/20250517122131_create_likes.rb
@@ -1,0 +1,8 @@
+class CreateLikes < ActiveRecord::Migration[7.1]
+  def change
+    create_table :likes do |t|
+      
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250517122131_create_likes.rb
+++ b/db/migrate/20250517122131_create_likes.rb
@@ -1,7 +1,8 @@
 class CreateLikes < ActiveRecord::Migration[7.1]
   def change
     create_table :likes do |t|
-      
+      t.references :user, null: false, foreign_key: true
+      t.references :post, null: false, foreign_key: true
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_05_01_083724) do
+ActiveRecord::Schema[7.1].define(version: 2025_05_17_122131) do
   create_table "active_storage_attachments", charset: "utf8mb3", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -39,6 +39,15 @@ ActiveRecord::Schema[7.1].define(version: 2025_05_01_083724) do
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
+  create_table "likes", charset: "utf8mb3", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "post_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["post_id"], name: "index_likes_on_post_id"
+    t.index ["user_id"], name: "index_likes_on_user_id"
+  end
+
   create_table "posts", charset: "utf8mb3", force: :cascade do |t|
     t.integer "duration", null: false
     t.text "result", null: false
@@ -63,5 +72,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_05_01_083724) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "likes", "posts"
+  add_foreign_key "likes", "users"
   add_foreign_key "posts", "users"
 end

--- a/spec/factories/likes.rb
+++ b/spec/factories/likes.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :like do
+    
+  end
+end

--- a/spec/helpers/likes_helper_spec.rb
+++ b/spec/helpers/likes_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the LikesHelper. For example:
+#
+# describe LikesHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe LikesHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/like_spec.rb
+++ b/spec/models/like_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Like, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/likes_request_spec.rb
+++ b/spec/requests/likes_request_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "Likes", type: :request do
+
+end


### PR DESCRIPTION
## 概要  
ユーザーが他のユーザーの投稿に対して「いいね」でリアクションできる機能を実装しました。  
将来的にはこの機能をベースに、リアクション型の投票機能やセンセーショナル投稿のランダム表示などへ発展させることを想定しています。

## 実施内容  
- `Like` モデルを作成（`user_id`, `post_id` の中間テーブル）
- Userモデル：`liked_posts`、Postモデル：`liking_users` を定義（throughアソシエーション）
- 同一ユーザーが同じ投稿に複数回いいねできないよう、バリデーションを追加
- `LikesController` を作成し、いいね登録・解除処理を実装
- `posts` にネストした単数リソースとして `like` をルーティングに追加
- 投稿詳細ページに「いいね」ボタンを表示
  - いいね済みかどうかでボタンの文言・見た目を切り替える
- 投稿ごとに現在の「いいね数」を表示

## 備考  
- 将来的に `Like` モデルを拡張・置き換える形で、複数リアクションに対応した `Reaction` モデルを導入予定
- 一覧ページやAjax対応、人気投稿の抽出機能なども今後のステップとして検討中

## 関連Issue  
Closes #58
