### PR TITLE
センセーショナル投稿の定義

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -10,4 +10,12 @@ class Post < ApplicationRecord
   end
 
   validates :duration, numericality: {only_integer: true, message: "は半角数字（整数）で入力してください"}
+
+  def self.sensational_sample
+    Post.left_joins(:likes)
+        .group(:id)
+        .order('COUNT(likes.id) DESC')
+        .limit(5)
+        .sample
+  end
 end


### PR DESCRIPTION
## 概要
トップページに「センセーショナル投稿」をランダム表示する機能の実装に向けて、表示対象とする投稿の定義（＝センセーショナル投稿の条件）を整備した。

## 実施内容
- Postモデルに `self.sensational_sample` メソッドを追加
  - いいね数の多い投稿を取得するため、`left_joins(:likes)` で結合
  - `group(:id)` と `order('COUNT(likes.id) DESC')` を使って投稿をいいね数順にソート
  - `.limit(5).sample` により、上位5件の中からランダムに1件選出
- 初期実装として「いいね数上位5件からランダムに1件選ぶ」方式とした
- 後続ステップでトップページへの表示処理に組み込む予定

## 関連Issue
Closes #62 